### PR TITLE
Add simulated annealing demo implementation

### DIFF
--- a/src/qtrax/__init__.py
+++ b/src/qtrax/__init__.py
@@ -1,1 +1,7 @@
+"""Q-TRAX Algorithm package."""
 
+__all__ = [
+    "core",
+    "models",
+    "utils",
+]

--- a/src/qtrax/core/__init__.py
+++ b/src/qtrax/core/__init__.py
@@ -1,1 +1,6 @@
+"""Core optimization algorithms for Q-TRAX."""
 
+from .annealer import simulated_annealing
+from .neighbor import two_opt
+
+__all__ = ["simulated_annealing", "two_opt"]

--- a/src/qtrax/core/annealer.py
+++ b/src/qtrax/core/annealer.py
@@ -1,1 +1,42 @@
+import math
+import random
+from typing import Callable, List, Tuple
 
+from ..models.problem import TSPProblem
+from .neighbor import two_opt
+
+
+def simulated_annealing(
+    problem: TSPProblem,
+    initial_route: List[int],
+    *,
+    initial_temp: float = 100.0,
+    cooling_rate: float = 0.95,
+    min_temp: float = 0.1,
+    max_iterations: int = 1000,
+    neighbor_func: Callable[[List[int]], List[int]] | None = None,
+) -> Tuple[List[int], float]:
+    """Simple simulated annealing algorithm for TSP."""
+    if neighbor_func is None:
+        neighbor_func = two_opt
+
+    current = initial_route[:]
+    current_cost = problem.evaluate(current)
+    best = current[:]
+    best_cost = current_cost
+
+    temp = initial_temp
+    iteration = 0
+    while temp > min_temp and iteration < max_iterations:
+        candidate = neighbor_func(current)
+        candidate_cost = problem.evaluate(candidate)
+        delta = candidate_cost - current_cost
+        if delta < 0 or random.random() < math.exp(-delta / temp):
+            current = candidate
+            current_cost = candidate_cost
+            if current_cost < best_cost:
+                best = current
+                best_cost = current_cost
+        temp *= cooling_rate
+        iteration += 1
+    return best, best_cost

--- a/src/qtrax/core/neighbor.py
+++ b/src/qtrax/core/neighbor.py
@@ -1,1 +1,11 @@
+import random
+from typing import List
 
+def two_opt(route: List[int]) -> List[int]:
+    """Return a new route by reversing a random subsequence (2-opt)."""
+    if len(route) < 2:
+        return route[:]
+    i, j = sorted(random.sample(range(len(route)), 2))
+    new_route = route[:]
+    new_route[i:j+1] = reversed(route[i:j+1])
+    return new_route

--- a/src/qtrax/main.py
+++ b/src/qtrax/main.py
@@ -1,1 +1,22 @@
+"""Entry point demonstrating a simple optimization run."""
 
+from .core import simulated_annealing
+from .models import TSPProblem
+
+
+def main() -> None:
+    distance_matrix = [
+        [0, 2, 9, 10],
+        [1, 0, 6, 4],
+        [15, 7, 0, 8],
+        [6, 3, 12, 0],
+    ]
+    problem = TSPProblem(distance_matrix)
+    initial_route = list(range(len(distance_matrix)))
+    best_route, best_cost = simulated_annealing(problem, initial_route)
+    print("Best route:", best_route)
+    print("Cost:", best_cost)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qtrax/models/__init__.py
+++ b/src/qtrax/models/__init__.py
@@ -1,1 +1,6 @@
+"""Problem and solution models."""
 
+from .problem import TSPProblem
+from .solution import Solution
+
+__all__ = ["TSPProblem", "Solution"]

--- a/src/qtrax/models/problem.py
+++ b/src/qtrax/models/problem.py
@@ -1,1 +1,18 @@
+from typing import Sequence
 
+
+class TSPProblem:
+    """Simple Traveling Salesman Problem representation."""
+
+    def __init__(self, distance_matrix: Sequence[Sequence[float]]):
+        self.distance_matrix = distance_matrix
+        self.size = len(distance_matrix)
+
+    def evaluate(self, route: Sequence[int]) -> float:
+        """Return total distance for the given cyclic route."""
+        cost = 0.0
+        m = self.distance_matrix
+        n = len(route)
+        for i in range(n):
+            cost += m[route[i]][route[(i + 1) % n]]
+        return cost

--- a/src/qtrax/models/solution.py
+++ b/src/qtrax/models/solution.py
@@ -1,1 +1,8 @@
+from dataclasses import dataclass
+from typing import Sequence
 
+
+@dataclass
+class Solution:
+    route: Sequence[int]
+    cost: float

--- a/src/qtrax/utils/__init__.py
+++ b/src/qtrax/utils/__init__.py
@@ -1,1 +1,5 @@
+"""Utility helpers for Q-TRAX."""
 
+from .timer import Timer
+
+__all__ = ["Timer"]

--- a/src/qtrax/utils/timer.py
+++ b/src/qtrax/utils/timer.py
@@ -1,1 +1,28 @@
+import time
+from typing import Optional
 
+class Timer:
+    """Simple timer context manager."""
+    def __init__(self) -> None:
+        self.start_time: Optional[float] = None
+        self.end_time: Optional[float] = None
+
+    def __enter__(self) -> 'Timer':
+        self.start()
+        return self
+
+    def start(self) -> None:
+        self.start_time = time.perf_counter()
+        self.end_time = None
+
+    def stop(self) -> None:
+        self.end_time = time.perf_counter()
+
+    def elapsed(self) -> float:
+        if self.start_time is None:
+            return 0.0
+        end = self.end_time if self.end_time is not None else time.perf_counter()
+        return end - self.start_time
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Add the src directory to sys.path so tests can import qtrax
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,1 +1,37 @@
+import random
+import time
 
+from qtrax.core import simulated_annealing
+from qtrax.models import TSPProblem
+from qtrax.utils import Timer
+
+
+def make_problem():
+    return TSPProblem([
+        [0, 2, 9, 10],
+        [1, 0, 6, 4],
+        [15, 7, 0, 8],
+        [6, 3, 12, 0],
+    ])
+
+
+def test_problem_evaluate():
+    problem = make_problem()
+    route = [0, 1, 2, 3]
+    assert problem.evaluate(route) == 2 + 6 + 8 + 6
+
+
+def test_simulated_annealing_improves():
+    problem = make_problem()
+    start_route = [0, 1, 2, 3]
+    random.seed(0)
+    best_route, best_cost = simulated_annealing(
+        problem, start_route, initial_temp=10.0, cooling_rate=0.9, max_iterations=500
+    )
+    assert best_cost <= problem.evaluate(start_route)
+
+
+def test_timer():
+    with Timer() as t:
+        time.sleep(0.01)
+    assert t.elapsed() >= 0.01

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,1 +1,16 @@
+from qtrax.models import TSPProblem, Solution
 
+
+def test_solution_dataclass():
+    s = Solution(route=[0, 1, 2], cost=5.0)
+    assert s.route == [0, 1, 2]
+    assert s.cost == 5.0
+
+
+def test_problem_size():
+    matrix = [
+        [0, 1],
+        [1, 0],
+    ]
+    problem = TSPProblem(matrix)
+    assert problem.size == 2


### PR DESCRIPTION
## Summary
- implement a minimal `Timer` utility
- add `TSPProblem` model and a simple simulated annealing algorithm
- provide example entry point in `qtrax.main`
- create tests for the models, timer and annealer
- configure test path with `tests/conftest.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fd13bb3388322bb2e6fc9ecda6949